### PR TITLE
Add in post build step to minify code using UglifyJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "uStyle React Components",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rm -rf dist; babel src --out-dir dist",
+    "build": "rm -rf dist; babel src --out-dir dist; echo Pre-Minify: `du -sh dist | cut -f1`",
+    "postbuild": "find dist -type f -exec uglifyjs {} --mangle --compress -o {} \\;; echo Post-Minify: `du -sh dist | cut -f1`",
     "start": "webpack-dev-server",
     "commit-dist": "npm run build; npm run lint:fix; git add dist",
     "bump-version": "nver; git add package.json",
@@ -34,8 +35,6 @@
     "react": ">=15.3"
   },
   "devDependencies": {
-    "react": ">=15.3",
-    "react-dom": ">=15.3",
     "babel-cli": "^6.24.0",
     "babel-core": "^6.24.0",
     "babel-loader": "^6.4.1",
@@ -44,7 +43,10 @@
     "nodemon": "^1.11.0",
     "nver": "^0.0.15",
     "pre-commit": "^1.2.2",
+    "react": ">=15.3",
+    "react-dom": ">=15.3",
     "standard": "^10.0.2",
+    "uglify-js": "^3.0.15",
     "webpack": "^2.3.3",
     "webpack-dev-server": "^2.4.2"
   }


### PR DESCRIPTION
I tried to use a couple of things directly with babel,

+ [**babili**](https://github.com/babel/babili) - Issue with `es2015` preset babel/babili#556
+ [**babel-plugin-uglify**](https://github.com/rreverser/babel-plugin-uglify) - Just didn't work...

So added the NPM script using the [UglifyJS2 CLI tool](https://github.com/mishoo/UglifyJS2) which saves _~20%_ of the size! ✌