### PR TITLE
Don't expose omit on the global window object

### DIFF
--- a/dist/components/Overlay/index.js
+++ b/dist/components/Overlay/index.js
@@ -84,9 +84,9 @@ var Overlay = function (_PureComponent) {
         return {
           visibility: 'closed'
         };
-      }
+      });
       // using uStyle's overlay, which means we need some class dancing here
-      );if ((0, _classHelpers.hasClass)(document.body, 'noscroll')) {
+      if ((0, _classHelpers.hasClass)(document.body, 'noscroll')) {
         this.enableScroll();
         setTimeout(function () {
           document.body.scrollTop = _this2.state.scrollTop;

--- a/dist/utils/omit.js
+++ b/dist/utils/omit.js
@@ -15,6 +15,4 @@ var omit = function omit(obj) {
   return newObj;
 };
 
-window.omit = omit;
-
 exports.default = omit;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ustyle-react",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "uStyle React Components",
   "main": "dist/index.js",
   "scripts": {

--- a/src/utils/omit.js
+++ b/src/utils/omit.js
@@ -4,6 +4,4 @@ const omit = (obj, ...keys) => {
   return newObj
 }
 
-window.omit = omit
-
 export default omit


### PR DESCRIPTION
Doing this breaks server-side rendering, so I've removed where it gets exposed as it doesn't seem necessary.