### PR TITLE
Adding --before and --after modifiers to the Icon component

### DIFF
--- a/dist/components/Icon/example.js
+++ b/dist/components/Icon/example.js
@@ -20,6 +20,7 @@ exports.default = function () {
     null,
     _react2.default.createElement(_index2.default, { name: 'cross', size: 'small' }),
     _react2.default.createElement(_index2.default, { name: 'facebook-brand' }),
-    _react2.default.createElement(_index2.default, { name: 'google', color: 'typecyan', size: 'large' })
+    _react2.default.createElement(_index2.default, { name: 'google', color: 'typecyan', size: 'large' }),
+    _react2.default.createElement(_index2.default, { name: 'tick', color: 'typegrey', size: 'small', before: true })
   );
 };

--- a/dist/components/Icon/index.js
+++ b/dist/components/Icon/index.js
@@ -72,11 +72,13 @@ var Icon = function (_PureComponent) {
           size = _props2.size,
           sizeTablet = _props2.sizeTablet,
           sizeMobile = _props2.sizeMobile,
-          noText = _props2.noText;
+          noText = _props2.noText,
+          before = _props2.before,
+          after = _props2.after;
 
       return (0, _classnames2.default)(this.props.className, (_cx = {
         'us-icon': true
-      }, _defineProperty(_cx, 'us-icon--' + size, size), _defineProperty(_cx, 'us-icon--' + sizeTablet + '--sm-tablet', sizeTablet), _defineProperty(_cx, 'us-icon--' + sizeMobile + '--mobile', sizeMobile), _defineProperty(_cx, 'us-icon--' + this.realColor, this.realColor), _defineProperty(_cx, 'us-icon--notext', noText), _cx));
+      }, _defineProperty(_cx, 'us-icon--' + size, size), _defineProperty(_cx, 'us-icon--' + sizeTablet + '--sm-tablet', sizeTablet), _defineProperty(_cx, 'us-icon--' + sizeMobile + '--mobile', sizeMobile), _defineProperty(_cx, 'us-icon--' + this.realColor, this.realColor), _defineProperty(_cx, 'us-icon--notext', noText), _defineProperty(_cx, 'us-icon--before', before), _defineProperty(_cx, 'us-icon--after', after), _cx));
     }
   }, {
     key: 'xlinkHref',
@@ -98,6 +100,8 @@ Icon.propTypes = {
   sizeMobile: _propTypes2.default.oneOf(SIZES),
   color: _propTypes2.default.oneOf(COLORS),
   noText: _propTypes2.default.bool.isRequired,
+  before: _propTypes2.default.bool.isRequired,
+  after: _propTypes2.default.bool.isRequired,
   iconPath: _propTypes2.default.string.isRequired
 };
 
@@ -105,5 +109,7 @@ Icon.defaultProps = {
   size: 'medium',
   color: 'custom',
   noText: false,
+  before: false,
+  after: false,
   iconPath: ICON_PATH
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ustyle-react",
-  "version": "0.0.89",
+  "version": "0.0.90",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/ustyle-react",
-  "version": "0.0.89",
+  "version": "0.0.90",
   "description": "uStyle React Components",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Icon/example.js
+++ b/src/components/Icon/example.js
@@ -6,5 +6,6 @@ export default () => (
     <Icon name='cross' size='small' />
     <Icon name='facebook-brand' />
     <Icon name='google' color='typecyan' size='large' />
+    <Icon name='tick' color='typegrey' size='small' before />
   </div>
 )

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -29,14 +29,16 @@ export default class Icon extends PureComponent {
     return CUSTOM_ICONS.indexOf(name) !== -1 ? name : color
   }
   get className () {
-    const { size, sizeTablet, sizeMobile, noText } = this.props
+    const { size, sizeTablet, sizeMobile, noText, before, after } = this.props
     return cx(this.props.className, {
       'us-icon': true,
       [`us-icon--${size}`]: size,
       [`us-icon--${sizeTablet}--sm-tablet`]: sizeTablet,
       [`us-icon--${sizeMobile}--mobile`]: sizeMobile,
       [`us-icon--${this.realColor}`]: this.realColor,
-      'us-icon--notext': noText
+      'us-icon--notext': noText,
+      'us-icon--before': before,
+      'us-icon--after': after
     })
   }
   get xlinkHref () {
@@ -60,6 +62,8 @@ Icon.propTypes = {
   sizeMobile: PropTypes.oneOf(SIZES),
   color: PropTypes.oneOf(COLORS),
   noText: PropTypes.bool.isRequired,
+  before: PropTypes.bool.isRequired,
+  after: PropTypes.bool.isRequired,
   iconPath: PropTypes.string.isRequired
 }
 
@@ -67,5 +71,7 @@ Icon.defaultProps = {
   size: 'medium',
   color: 'custom',
   noText: false,
+  before: false,
+  after: false,
   iconPath: ICON_PATH
 }


### PR DESCRIPTION
<img width="662" alt="screen shot 2018-07-24 at 16 49 53" src="https://user-images.githubusercontent.com/5781504/43150364-a332da38-8f61-11e8-8836-483074b1f754.png">

`--before` modifier for the right margin