### PR TITLE
Migrate to not use asset.uswitch.com path

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <title>Hello React Webpack Tutorial!</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href='//assets0.uswitch.com/s3/uswitch-assets-eu/ustyle/ustyle-latest.css' media='all' rel='stylesheet' type='text/css' />
+    <link href='//www.uswitch.com/s3/uswitch-assets-eu/ustyle/ustyle-latest.css' media='all' rel='stylesheet' type='text/css' />
     <style>
      body { margin-bottom: 200px;}
      .tooltip-demo {


### PR DESCRIPTION
This change migrates use from an asset subdomain to use the main Uswitch www domain name. The aim of which is to reduce the number of SSL connections that need to be made by the browser.

Anything previously avaliable from assets.uswitch.com/s3/ should now be avaliable on www.uswitch.com/s3/

[_Created by Sourcegraph batch change `jonathan-fielding/asset-subdomain-removal`._](https://rvu.sourcegraph.com/users/jonathan-fielding/batch-changes/asset-subdomain-removal)